### PR TITLE
Fix DELETE method, and trimmer router

### DIFF
--- a/Sources/KituraSample/main.swift
+++ b/Sources/KituraSample/main.swift
@@ -94,6 +94,7 @@ router.put("/hello") {request, response, next in
 router.delete("/hello") {request, response, next in
     response.setHeader("Content-Type", value: "text/plain; charset=utf-8")
     do {
+        name = nil
         try response.status(HttpStatusCode.OK).send("Got a DELETE request").end()
     } catch {
         Log.error("Failed to send response \(error)")
@@ -168,7 +169,7 @@ router.get("/trimmer") { _, response, next in
         dateFormatter.dateStyle = .mediumStyle
         context["format"] = dateFormatter
 
-        try response.render("document", context: context).end()
+        try response.status(HttpStatusCode.OK).render("document", context: context).end()
     } catch {
         Log.error("Failed to render template \(error)")
     }


### PR DESCRIPTION
DELETE method of `/hello` should remove the name.
`/trimmer` should return status HTTP 200 OK instead of HTTP 404.
