### PR TITLE
Link to documentation in Kitura master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-This is a sample [Kitura](https://github.com/IBM-Swift/Kitura) application. See instructions for [Installation on OS X ](https://github.com/IBM-Swift/Kitura#installation-os-x) or [Installation on Linux](https://github.com/IBM-Swift/Kitura#installation-linux-apt-based).
+This is a sample [Kitura](https://github.com/IBM-Swift/Kitura/tree/master) application. See instructions for [Installation on OS X ](https://github.com/IBM-Swift/Kitura/tree/master#installation-os-x) or [Installation on Linux](https://github.com/IBM-Swift/Kitura/tree/master#installation-linux-apt-based).
 
 ## Clone, build and run
 1. `git clone https://github.com/IBM-Swift/Kitura-Sample.git && cd Kitura-Sample`


### PR DESCRIPTION
Links to Kitura installation instructions need to explicitly link to the master branch, since the default was changed to 'develop'.  Otherwise, the Kitura-Sample documentation may direct you to install a newer Swift snapshot which is only appropriate for the develop branch.