### PR TITLE
IBM-Swift/Kitura-Sample#33 Throw custom error that implements Swift.Error

### DIFF
--- a/Sources/KituraSample/main.swift
+++ b/Sources/KituraSample/main.swift
@@ -84,10 +84,23 @@ router.delete("/hello") {request, response, next in
 }
 
 // Error handling example
+enum SampleError: Swift.Error {
+    case sampleError
+}
+
+extension SampleError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .sampleError:
+            return "Example of error being set"
+        }
+    }
+}
+
 router.get("/error") { _, response, next in
     Log.error("Example of error being set")
     response.status(.internalServerError)
-    response.error = NSError(domain: "RouterTestDomain", code: 1, userInfo: [:])
+    response.error = SampleError.sampleError
     next()
 }
 


### PR DESCRIPTION
There is a problem of bridging between NSError and Swift.Error on Linux that causes segfault when we try to set response.error as NSError.
This PR adds a custom error enumeration (that implements Swift.Error) to demonstrate error handling.
