### PR TITLE
Initialize Log.logger once across all tests to avoid crash

### DIFF
--- a/Tests/KituraSampleRouterTests/KituraSampleTests.swift
+++ b/Tests/KituraSampleRouterTests/KituraSampleTests.swift
@@ -18,7 +18,7 @@ import XCTest
 import KituraNet
 import Foundation
 
-class KituraSampleTests: XCTestCase {
+class KituraSampleTests: KituraTest {
 
     static var allTests: [(String, (KituraSampleTests) -> () throws -> Void)] {
         return [
@@ -51,14 +51,6 @@ class KituraSampleTests: XCTestCase {
             ("testPostPutDeletePostHello", testPostPutDeletePostHello),
             ("testPutPostDeletePutHello", testPutPostDeletePutHello)
         ]
-    }
-
-    override func setUp() {
-        doSetUp()
-    }
-
-    override func tearDown() {
-        doTearDown()
     }
 
     func testURLParameters() {

--- a/Tests/KituraSampleRouterTests/KituraTest.swift
+++ b/Tests/KituraSampleRouterTests/KituraTest.swift
@@ -24,19 +24,16 @@ import Foundation
 
 import KituraSampleRouter
 
-protocol KituraTest {
-    func expectation(_ index: Int) -> XCTestExpectation
-    func waitExpectation(timeout t: TimeInterval, handler: XCWaitCompletionHandler?)
-}
-
-extension KituraTest {
-
-    func doSetUp() {
+class KituraTest: XCTestCase {
+    private static let initOnce: () = {
         HeliumLogger.use()
+    }()
+
+    override func setUp() {
+        KituraTest.initOnce
     }
 
-    func doTearDown() {
-        // sleep(10)
+    override func tearDown() {
     }
 
     func performServerTest(asyncTasks: @escaping (XCTestExpectation) -> Void...) {
@@ -101,9 +98,7 @@ extension KituraTest {
         }
         dispatchGroup.wait()
     }
-}
 
-extension XCTestCase: KituraTest {
     func expectation(_ index: Int) -> XCTestExpectation {
         let expectationDescription = "\(type(of: self))-\(index)"
         return self.expectation(description: expectationDescription)


### PR DESCRIPTION
See IBM-Swift/Kitura#996

Kitura-Sample tests crash frequently on linux. The backtraces always have a thread in the following chunk of code:
```
static Log.info(msg=<unavailable>, functionName="***", lineNum=168, fileName="***", self=0x00000000006697d8) -> String, functionName : String, lineNum : Int, fileName : String) -> () + 801 at Logger.swift:130
    frame #15: 0x00000000004e7954 
HTTPServer.listen(listenSocket=0x00000000024f4760, self=0x00000000024f45b0) -> () + 2612 at HTTPServer.swift:168
```

The crash happens when the log message for the server stopping from the previous unit test runs into contention with the newly initialized HeliumLogger instance of the new test. The crashes stop if we make the call to initialize the static Log.logger one time like it was intended.