### PR TITLE
IBM-Swift/Kitura#1031 bumped the version of Stencil Template Engine

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .Package(url: "https://github.com/IBM-Swift/Kitura.git", majorVersion: 1, minor: 6),
         .Package(url: "https://github.com/IBM-Swift/HeliumLogger.git", majorVersion: 1, minor: 6),
         .Package(url: "https://github.com/IBM-Swift/Kitura-MustacheTemplateEngine.git", majorVersion: 1, minor: 6),
-        .Package(url: "https://github.com/IBM-Swift/Kitura-StencilTemplateEngine.git", majorVersion: 1, minor: 6),
-        .Package(url: "https://github.com/IBM-Swift/Kitura-Markdown", majorVersion: 0, minor: 8) 
+        .Package(url: "https://github.com/IBM-Swift/Kitura-StencilTemplateEngine.git", majorVersion: 1, minor: 7),
+        .Package(url: "https://github.com/IBM-Swift/Kitura-Markdown", majorVersion: 0, minor: 8)
     ]
 )

--- a/Sources/KituraSampleRouter/RouterCreator.swift
+++ b/Sources/KituraSampleRouter/RouterCreator.swift
@@ -154,13 +154,13 @@ public struct RouterCreator {
         router.get("/user/:id", allowPartialMatch: false, middleware: CustomParameterMiddleware())
         router.get("/user/:id", handler: customParameterHandler)
 
-        // add Stencil Template Engine with a namespace with a custom tag
-        let namespace = Namespace()
+        // add Stencil Template Engine with an extension with a custom tag
+        let `extension` = Extension()
         // from https://github.com/kylef/Stencil/blob/master/ARCHITECTURE.md#simple-tags
-        namespace.registerSimpleTag("custom") { _ in
+        `extension`.registerSimpleTag("custom") { _ in
             return "Hello World"
         }
-        router.add(templateEngine: StencilTemplateEngine(namespace: namespace))
+        router.add(templateEngine: StencilTemplateEngine(extension: `extension`))
 
         // Support for Mustache implemented for OSX only yet
         #if !os(Linux)


### PR DESCRIPTION
Namespace changed to Extension in Stencil 0.8