### PR TITLE
IBM-Swift/Kitura#1075 Add travis ubuntu 16.04 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,18 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04
     - os: linux
       dist: trusty
       sudo: required
       env: SWIFT_VERSION=3.0.2
+    - os: linux
+      dist: trusty
+      sudo: required
     - os: osx
       osx_image: xcode8.3
       sudo: required
 
-before_install:
-  - git clone https://github.com/IBM-Swift/Package-Builder.git
-  - test -n "$SWIFT_VERSION" && echo "$SWIFT_VERSION" > .swift-version || echo "SWIFT_VERSION not set, using $(cat .swift-version)"
-
 script:
-  - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR
+  - ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o verbose
+
+if [ -n "${DOCKER_IMAGE}" ]; then
+    docker pull ${DOCKER_IMAGE}
+    docker run --env SWIFT_VERSION -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 && cd $TRAVIS_BUILD_DIR && ./build.sh"
+else
+    test -n "${SWIFT_VERSION}" && echo "${SWIFT_VERSION}" > .swift-version || echo "SWIFT_VERSION not set, using $(cat .swift-version)"
+    git clone https://github.com/IBM-Swift/Package-Builder.git
+    ./Package-Builder/build-package.sh -projectDir $(pwd)
+fi


### PR DESCRIPTION
## Description
Add travis builds on the latest ubuntu LTS version (16.04) in addition to 14.04 (Bluemix support).

Travis does not have a ubuntu 16.04 environment, so we need to tweak our build scripts to run on docker using a ubuntu 16.04 image.

## Motivation and Context
IBM-Swift/Kitura#1075