### PR TITLE
Update dependencies for Kitura 2.3 release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,11 +28,11 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.2.0")),
-        .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", .upToNextMinor(from: "1.7.0")),
-        .package(url: "https://github.com/IBM-Swift/Kitura-StencilTemplateEngine.git", .upToNextMinor(from: "1.9.0")),
-        .package(url: "https://github.com/IBM-Swift/Kitura-Markdown", .upToNextMinor(from: "0.9.0")),
-        .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", .upToNextMinor(from: "1.0.1"))
+        .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.3.0"),
+        .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.7.1"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-StencilTemplateEngine.git", from: "1.9.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-Markdown", from: "1.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", from: "2.0.0")
     ],
     targets: [
       .target(name: "Kitura-Sample",


### PR DESCRIPTION
- Update to appropriate dependencies for the Kitura 2.3 release
- Relax minor constraints as these are no longer necessary

Note that this will no longer require Kitura-Sample to be updated when a new minor of Kitura is released.