### PR TITLE
moved OpenAPI into postinit

### DIFF
--- a/Sources/Application/Application.swift
+++ b/Sources/Application/Application.swift
@@ -38,7 +38,6 @@ public class App {
     public init() throws {
         // Run the metrics initializer
         initializeMetrics(router: router)
-        KituraOpenAPI.addEndpoints(to: router)
     }
     
     func postInit() throws {
@@ -53,6 +52,7 @@ public class App {
         initializeStaticFileServers(app: self)
         initializeMiscRoutes(app: self)
         initializeNotFoundRoute(app: self)
+        KituraOpenAPI.addEndpoints(to: router)
     }
     
     public func run() throws {


### PR DESCRIPTION
After the Kitura sample refactor the webpages would not load from other folders (e.g. Views) although direct routes such as hello still worked. This only happened when the app was pushed to the cloud and not while running locally. 

After some trial and error I found that adding the openAPI routes caused this to happen and it could be fixed by moving them into the postinit function instead of the init function.