### PR TITLE
remove duplicate Oauth2 route

### DIFF
--- a/Views/index.html
+++ b/Views/index.html
@@ -31,15 +31,13 @@
             <li class="list"><button class="button" onclick="loadInnerPage('./stencil')"><p>Rendering stencil templates</p></button></li>
 
             <li class="list"><button class="button" onclick="loadInnerPage('./docs/index')"><p>Rendering markdown</p></button></li>
-            
-            <li class="list"><button class="button" onclick="loadInnerPage('./basicauth.html')"><p>HTTP basic authentication</p></button></li>
-            
-            <li class="list"><button class="button" onclick="loadInnerPage('./tokenauth.html')"><p>OAuth2 token authentication</p></button></li>
-            
-            <li class="list"><button class="button" onclick="loadInnerPage('./oauth2.html')"><p>OAuth2 redirecting authentication</p></button></li>
-            
-            <li class="list"><button class="button" onclick="loadInnerPage('./oauth2.html')"><p>OAuth2 redirecting authentication</p></button></li>
 
+            <li class="list"><button class="button" onclick="loadInnerPage('./basicauth.html')"><p>HTTP basic authentication</p></button></li>
+
+            <li class="list"><button class="button" onclick="loadInnerPage('./tokenauth.html')"><p>OAuth2 token authentication</p></button></li>
+
+            <li class="list"><button class="button" onclick="loadInnerPage('./oauth2.html')"><p>OAuth2 redirecting authentication</p></button></li>
+            
             <li class="list"><button class="button" onclick="loadInnerPage('./openapi/ui')"><p>OpenAPI interface</p></button></li>
 
             <li class="list"><button class="button" onclick="loadInnerPage('./chat')"><p>WebSockets demo</p></button></li>
@@ -49,23 +47,23 @@
     <div class="sidebar-mobile">
         <ul>
             <li style="margin: 5px -15px"><button class="button" onclick="window.open('./hello.html')"><p>Hello World</p></button></li>
-            
+
             <li class="list"><button class="button" onclick="window.open('./codable.html')"><p>Codable routing</p></button></li>
-            
+
             <li class="list"><button class="button" onclick="window.open('./ormdatabase.html')"><p>Persisting with a database</p></button></li>
-            
+
             <li class="list"><button class="button" onclick="window.open('./sessions.html')"><p>Persisting with sessions</p></button></li>
-            
+
             <li class="list"><button class="button" onclick="window.open('./stencil')"><p>Rendering stencil templates</p></button></li>
-            
+
             <li class="list"><button class="button" onclick="window.open('./docs/index')"><p>Rendering markdown</p></button></li>
 
             <li class="list"><button class="button" onclick="window.open('./basicauth.html')"><p>HTTP basic authentication</p></button></li>
-            
+
             <li class="list"><button class="button" onclick="window.open('./tokenauth.html')"><p>OAuth2 token authentication</p></button></li>
-            
+
             <li class="list"><button class="button" onclick="window.open('./oauth2.html')"><p>OAuth2 redirecting authentication</p></button></li>
-            
+
             <li class="list"><button class="button" onclick="window.open('./openapi/ui')"><p>OpenAPI interface</p></button></li>
 
             <li class="list"><button class="button" onclick="window.open('./further.html')"><p>Further routing examples</p></button></li>


### PR DESCRIPTION
In the last commit we accidentally added a second Redirecting Oauth2 route to the index page.

This PR removes the extra page as well as removing white space on the page.