### PR TITLE
Feat: Add Manifest and Docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibmcom/swift-ubuntu-runtime:4.1.1
+FROM ibmcom/swift-ubuntu-runtime:4.2
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu-runtime image."
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG bx_dev_user=root
 ARG bx_dev_userid=1000
 
 # Install system level packages
-# RUN apt-get update && apt-get dist-upgrade -y
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y libpq-dev && apt-get clean
 
 # Add utils files
 ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/run-utils.sh /swift-utils/run-utils.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ibmcom/swift-ubuntu-runtime:4.1.1
+LABEL maintainer="IBM Swift Engineering at IBM Cloud"
+LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu-runtime image."
+
+# We can replace this port with what the user wants
+EXPOSE 8080
+
+# Default user if not provided
+ARG bx_dev_user=root
+ARG bx_dev_userid=1000
+
+# Install system level packages
+# RUN apt-get update && apt-get dist-upgrade -y
+
+# Add utils files
+ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/run-utils.sh /swift-utils/run-utils.sh
+ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/common-utils.sh /swift-utils/common-utils.sh
+RUN chmod -R 555 /swift-utils
+
+# Create user if not root
+RUN if [ $bx_dev_user != "root" ]; then useradd -ms /bin/bash -u $bx_dev_userid $bx_dev_user; fi
+
+# Bundle application source & binaries
+COPY . /swift-project
+
+# Command to start Swift application
+CMD [ "sh", "-c", "cd /swift-project && .build-ubuntu/release/Kitura-Sample" ]

--- a/Dockerfile-tools
+++ b/Dockerfile-tools
@@ -1,4 +1,4 @@
-FROM ibmcom/swift-ubuntu:4.1.1
+FROM ibmcom/swift-ubuntu:4.2
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu image."
 

--- a/Dockerfile-tools
+++ b/Dockerfile-tools
@@ -1,0 +1,30 @@
+FROM ibmcom/swift-ubuntu:4.1.1
+LABEL maintainer="IBM Swift Engineering at IBM Cloud"
+LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu image."
+
+# We can replace this port with what the user wants
+EXPOSE 8080 1024 1025
+
+# Default user if not provided
+ARG bx_dev_user=root
+ARG bx_dev_userid=1000
+
+# Install system level packages
+# RUN apt-get update && apt-get dist-upgrade -y
+
+# Add utils files
+ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/tools-utils.sh /swift-utils/tools-utils.sh
+ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/common-utils.sh /swift-utils/common-utils.sh
+RUN chmod -R 555 /swift-utils
+
+# Create user if not root
+RUN if [ "$bx_dev_user" != root ]; then useradd -ms /bin/bash -u $bx_dev_userid $bx_dev_user; fi
+
+# Make password not required for sudo.
+# This is necessary to run 'tools-utils.sh debug' script when executed from an interactive shell.
+# This will not affect the deploy container.
+RUN echo "$bx_dev_user ALL=NOPASSWD: ALL" > /etc/sudoers.d/user && \
+    chmod 0440 /etc/sudoers.d/user
+
+# Bundle application source & binaries
+COPY . /swift-project

--- a/Dockerfile-tools
+++ b/Dockerfile-tools
@@ -10,7 +10,7 @@ ARG bx_dev_user=root
 ARG bx_dev_userid=1000
 
 # Install system level packages
-# RUN apt-get update && apt-get dist-upgrade -y
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y libpq-dev && apt-get clean
 
 # Add utils files
 ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/tools-utils.sh /swift-utils/tools-utils.sh

--- a/README.md
+++ b/README.md
@@ -165,10 +165,6 @@ where YOUR_ORG is the organisation you used when signing up to IBM Cloud and YOU
 bx app push
 ```
 
-Open your browser to the deployed provided URL to see the application running. You can now update the URL used with KituraKit in the FoodTracker application to connect from the iOS app.
-
-**Note:** The Database routes will not function unless you set up and connect the sample to a PostgreSQL database in the cloud.
-
 ---
 
 ## License

--- a/README.md
+++ b/README.md
@@ -135,6 +135,38 @@ To run the tests locally, run `swift test` from the Kitura-Sample directory.
 
 You can also run this sample application inside Xcode. For more details, visit [kitura.io](http://www.kitura.io/en/starter/xcode.html).
 
+## Running with Docker
+A description of the files related to Docker can be found in the [Docker files](#docker-files) setion. To build the two docker images, run the following commands from the root directory of the project:
+* `docker build -t myapp-run .`
+* `docker build -t myapp-build -f Dockerfile-tools .`
+You may customize the names of these images by specifying a different value after the `-t` option.
+
+To compile the application using the tools docker image, run:
+* `docker run -v $PWD:/swift-project -w /swift-project myapp-build /swift-utils/tools-utils.sh build release`
+
+To run the application:
+* `docker run -it -p 8080:8080 -v $PWD:/swift-project -w /swift-project myapp-run sh -c .build-ubuntu/release/Kitura-Sample`
+
+## Deploy to Cloud Foundry
+
+1. Log in to IBM Cloud
+
+```
+bluemix api https://api.ng.bluemix.net
+bluemix login
+bluemix target -o <YOUR_ORG> -s <YOUR_DEV_SPACE>
+```
+
+where YOUR_ORG is the organisation you used when signing up to IBM Cloud and YOUR_DEV_SPACE is the space you created.
+
+2. Deploy your application to IBM Cloud
+
+```
+bx app push
+```
+
+Open your browser to the deployed provided URL to see the application running. You can now update the URL used with KituraKit in the FoodTracker application to connect from the iOS app.
+
 ---
 
 ## License

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ bx app push
 
 Open your browser to the deployed provided URL to see the application running. You can now update the URL used with KituraKit in the FoodTracker application to connect from the iOS app.
 
+**Note:** The Database routes will not function unless you set up and connect the sample to a PostgreSQL database in the cloud.
+
 ---
 
 ## License

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,9 @@
+---
+applications:
+- instances: 1
+  timeout: 180
+  name: Kitura-Sample
+  buildpack: swift_buildpack
+  command: "'Kitura-Sample'"
+  memory: 128M
+  random-route: true


### PR DESCRIPTION
This PR adds the Dockerfile, Dockerfile-tool and manifest file which are normally provided by Kitura init. 
This allows you to build the project with Docker and deploy it to cloud foundry.

The readme has been updated with instructions on how to build the app with Docker and deploy the sample app to Cloud foundry.