### PR TITLE
Delete link to removed ORM example

### DIFF
--- a/Views/index.html
+++ b/Views/index.html
@@ -24,8 +24,6 @@
 
             <li class="list"><button class="button" onclick="loadInnerPage('./codable.html')"><p>Codable routing</p></button></li>
 
-            <li class="list"><button class="button" onclick="loadInnerPage('./ormdatabase.html')"><p>Persisting with a database</p></button></li>
-
             <li class="list"><button class="button" onclick="loadInnerPage('./sessions.html')"><p>Persisting with sessions</p></button></li>
 
             <li class="list"><button class="button" onclick="loadInnerPage('./stencil')"><p>Rendering stencil templates</p></button></li>
@@ -51,8 +49,6 @@
             <li style="margin: 5px -15px"><button class="button" onclick="window.open('./hello.html')"><p>Hello World</p></button></li>
 
             <li class="list"><button class="button" onclick="window.open('./codable.html')"><p>Codable routing</p></button></li>
-
-            <li class="list"><button class="button" onclick="window.open('./ormdatabase.html')"><p>Persisting with a database</p></button></li>
 
             <li class="list"><button class="button" onclick="window.open('./sessions.html')"><p>Persisting with sessions</p></button></li>
 


### PR DESCRIPTION
This PR removes the Link to the deleted ORM example. Currently this link doesn't go to any page since the example has been deleted. Once we create a dummy database we can add the example back in.