### PR TITLE
removed appID by default for Mac

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,42 +20,48 @@
 import PackageDescription
 import Foundation
 
-var webSocketPackage: Package.Dependency
+var dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.5.0"),
+    .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.7.1"),
+    .package(url: "https://github.com/IBM-Swift/CloudEnvironment.git", from: "8.0.0"),
+    .package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", from: "2.5.0"),
+    .package(url: "https://github.com/IBM-Swift/Health.git", from: "1.0.0"),
+    .package(url: "https://github.com/IBM-Swift/Kitura-OpenAPI.git", from: "1.1.0"),
+    .package(url: "https://github.com/IBM-Swift/Kitura-StencilTemplateEngine.git", from: "1.9.0"),
+    .package(url: "https://github.com/IBM-Swift/Kitura-Markdown.git", from: "1.0.0"),
+    .package(url: "https://github.com/IBM-Swift/Kitura-CredentialsHTTP.git", from: "2.1.0"),
+    .package(url: "https://github.com/IBM-Swift/Kitura-Session.git", from: "3.3.0"),
+    .package(url: "https://github.com/IBM-Swift/Kitura-CredentialsGoogle.git", from: "2.2.0"),
+    .package(url: "https://github.com/IBM-Swift/Kitura-CredentialsFacebook.git", from: "2.2.0"),
+    .package(url: "https://github.com/IBM-Swift/Swift-JWT", from: "3.0.0"),
+    .package(url: "https://github.com/IBM-Swift/Swift-Kuery-ORM.git", .upToNextMinor(from: "0.3.1")),
+]
+var targetDependencies: [Target.Dependency] = [ "Kitura", "CloudEnvironment","SwiftMetrics","Health", "KituraOpenAPI", "KituraMarkdown", "KituraStencil", "CredentialsHTTP", "KituraSession", "CredentialsGoogle", "CredentialsFacebook", "SwiftJWT", "SwiftKueryORM",
+]
+
+// Uncomment to use PostgreSQL
+// dependencies.append(.package(url: "https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL.git", from: "1.2.0"))
+// targetDependencies.append("SwiftKueryPostgreSQL")
+
+// IBMCloudAppID requires OpenSSL that is not included on Mac by default.
+#if os(Linux)
+dependencies.append(.package(url: "https://github.com/ibm-cloud-security/appid-serversdk-swift", .branch("development")))
+targetDependencies.append("IBMCloudAppID")
+#endif
 
 // Temporarily use alternate branch of Kitura-WebSocket while building in NIO mode
 if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
-    webSocketPackage = .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", .exact("0.1.0-nio"))
+    dependencies.append(.package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", .exact("0.1.0-nio")))
 } else {
-    webSocketPackage = .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", from: "2.0.0")
+    dependencies.append(.package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", from: "2.0.0"))
 }
 
 let package = Package(
     name: "Kitura-Sample",
-    dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.5.0"),
-        .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.7.1"),
-        .package(url: "https://github.com/IBM-Swift/CloudEnvironment.git", from: "8.0.0"),
-        .package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", from: "2.5.0"),
-        .package(url: "https://github.com/IBM-Swift/Health.git", from: "1.0.0"),
-        .package(url: "https://github.com/IBM-Swift/Kitura-OpenAPI.git", from: "1.1.0"),
-        .package(url: "https://github.com/IBM-Swift/Kitura-StencilTemplateEngine.git", from: "1.9.0"),
-        .package(url: "https://github.com/IBM-Swift/Kitura-Markdown.git", from: "1.0.0"),
-        webSocketPackage,
-        .package(url: "https://github.com/IBM-Swift/Kitura-CredentialsHTTP.git", from: "2.1.0"),
-        .package(url: "https://github.com/IBM-Swift/Kitura-Session.git", from: "3.3.0"),
-        .package(url: "https://github.com/IBM-Swift/Kitura-CredentialsGoogle.git", from: "2.2.0"),
-        .package(url: "https://github.com/IBM-Swift/Kitura-CredentialsFacebook.git", from: "2.2.0"),
-        .package(url: "https://github.com/Andrew-Lees11/appid-serversdk-swift.git", .branch("master")),
-        .package(url: "https://github.com/IBM-Swift/Swift-JWT", from: "3.0.0"),
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery-ORM.git", .upToNextMinor(from: "0.3.1")),
-        // Uncomment to use PostgreSQL
-        //.package(url: "https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL.git", from: "1.2.0"),
-    ],
+    dependencies: dependencies,
     targets: [
         .target(name: "Kitura-Sample", dependencies: [ .target(name: "Application"), .target(name: "ChatService"), "Kitura" , "HeliumLogger"]),
-        .target(name: "Application", dependencies: [ "Kitura", "CloudEnvironment","SwiftMetrics","Health", "KituraOpenAPI", "KituraMarkdown", "KituraStencil", "CredentialsHTTP", "KituraSession", "CredentialsGoogle", "CredentialsFacebook", "IBMCloudAppID", "SwiftJWT", "SwiftKueryORM",
-            // Uncomment to use PostgreSQL
-            /*"SwiftKueryPostgreSQL"*/]),
+        .target(name: "Application", dependencies: targetDependencies),
         .target(name: "ChatService", dependencies: ["Kitura-WebSocket"]),
         .testTarget(name: "KituraSampleRouterTests" , dependencies: [.target(name: "Application"), "Kitura","HeliumLogger" ])
     ]

--- a/Sources/Application/Routes/Oauth2Routes.swift
+++ b/Sources/Application/Routes/Oauth2Routes.swift
@@ -18,7 +18,13 @@ import Credentials
 import CredentialsFacebook
 import CredentialsGoogle
 import KituraSession
+// IBMCloudAppID requires OpenSSL that is not included on Mac by default.
+// To use this on mac, install OpenSSL:
+// `$ brew install openssl`
+// then remove all the `#if os(Linux)` tags for AppID in Kitura sample.
+#if os(Linux)
 import IBMCloudAppID
+#endif
 
 func initializeOauth2Routes(app: App) {
     
@@ -83,6 +89,8 @@ func initializeOauth2Routes(app: App) {
     // AppID Oauth Setup
     let kituraCredentials = Credentials()
     
+    // IBMCloudAppID requires OpenSSL that is not included on Mac by default.
+    #if os(Linux)
     if #available(OSX 10.12, *) {
         let webappKituraCredentialsPlugin = WebAppKituraCredentialsPlugin(options: appIdOptions)
         kituraCredentials.register(plugin: webappKituraCredentialsPlugin)
@@ -98,6 +106,7 @@ func initializeOauth2Routes(app: App) {
                                                                failureRedirect: "/oauth2.html"
         ))
     }
+    #endif
     
     // Route which only allows access if the user has authenticated with either AppID, Facebook or Google
     app.router.get("/oauth2/protected") { request, response, next in

--- a/Views/oauth2.html
+++ b/Views/oauth2.html
@@ -45,6 +45,12 @@
           </p><br>
           <a href="https://github.com/IBM-Swift/Kitura-Sample/blob/master/Sources/Application/Routes/Oauth2Routes.swift" target="_blank" class="inLink">View the code</a>
       <h2>App ID log in</h2>
+      <p>
+      AppID requires OpenSSL that is not included on Mac by default.<br>
+      To use this on mac, install OpenSSL:<br>
+      $ brew install openssl<br>
+      then remove all the `#if os(Linux)` tags for AppID in Kitura sample.<br>
+      </p>
       <ul><li>
           <a href="https://console.bluemix.net/docs/services/appid/index.html" target="_blank">Set up an App ID Oauth2 app </a><br>
           <p>Log in with App ID by making a get request to &quot;/oauth2/appid&quot;.</p>

--- a/openssl.xcconfig
+++ b/openssl.xcconfig
@@ -1,2 +1,0 @@
-HEADER_SEARCH_PATHS = /usr/local/opt/openssl/include
-LIBRARY_SEARCH_PATHS = /usr/local/opt/openssl/lib


### PR DESCRIPTION
This pull request removed AppID for MacOS. This is done because appID requires OpenSSL which is not installed by default on mac. With this change you should no longer need OpenSSL installed to run Kitura sample.