### PR TITLE
Fix: Removed Codable sessions example in swift 4.0

### DIFF
--- a/Sources/Application/Routes/SessionsRoutes.swift
+++ b/Sources/Application/Routes/SessionsRoutes.swift
@@ -33,7 +33,8 @@ func initializeSessionsRoutes(app: App) {
         respondWith(nil)
     }
     
-    // Raw session
+    // Raw session (Available from swift 4.1)
+    #if swift(>=4.1)
     let session = Session(secret: "secret", cookie: [CookieParameter.name("Raw-cookie")])
     app.router.all(middleware: session)
     
@@ -67,4 +68,5 @@ func initializeSessionsRoutes(app: App) {
         let _ = response.send(status: .noContent)
         next()
     }
+    #endif
 }

--- a/Tests/KituraSampleRouterTests/TestSessionsRoutes.swift
+++ b/Tests/KituraSampleRouterTests/TestSessionsRoutes.swift
@@ -22,6 +22,7 @@ import KituraSession
 class TestSessionsRoutes: KituraTest {
     
     static var allTests: [(String, (TestSessionsRoutes) -> () throws -> Void)] {
+        #if swift(>=4.1)
         return [
             ("testGetTypeSafeSession", testGetTypeSafeSession),
             ("testPostTypeSafeSession", testPostTypeSafeSession),
@@ -30,6 +31,13 @@ class TestSessionsRoutes: KituraTest {
             ("testPostRawSession", testPostRawSession),
             ("testRawSessionPersistence", testRawSessionPersistence),
         ]
+        #else
+        [
+            ("testGetTypeSafeSession", testGetTypeSafeSession),
+            ("testPostTypeSafeSession", testPostTypeSafeSession),
+            ("testTypeSafeSessionPersistence", testTypeSafeSessionPersistence),
+        ]
+        #endif
     }
     
     func testGetTypeSafeSession() {
@@ -73,6 +81,7 @@ class TestSessionsRoutes: KituraTest {
             })
         })
     }
+    #if swift(>=4.1)
     func testGetRawSession() {
         let emptyBooks: [Book] = []
         performServerTest(asyncTasks: { expectation in
@@ -84,7 +93,6 @@ class TestSessionsRoutes: KituraTest {
         })
     }
     
-    #if swift(>=4.1)
     func testPostRawSession() {
         let jsonBook: String = "{\"name\": \"bookName\",\"author\": \"bookAuthor\",\"rating\": 4}"
         let objectBook = Book(name: "bookName", author: "bookAuthor", rating: 4)

--- a/Tests/KituraSampleRouterTests/TestSessionsRoutes.swift
+++ b/Tests/KituraSampleRouterTests/TestSessionsRoutes.swift
@@ -32,7 +32,7 @@ class TestSessionsRoutes: KituraTest {
             ("testRawSessionPersistence", testRawSessionPersistence),
         ]
         #else
-        [
+        return [
             ("testGetTypeSafeSession", testGetTypeSafeSession),
             ("testPostTypeSafeSession", testPostTypeSafeSession),
             ("testTypeSafeSessionPersistence", testTypeSafeSessionPersistence),

--- a/Tests/KituraSampleRouterTests/TestSessionsRoutes.swift
+++ b/Tests/KituraSampleRouterTests/TestSessionsRoutes.swift
@@ -84,6 +84,7 @@ class TestSessionsRoutes: KituraTest {
         })
     }
     
+    #if swift(>=4.1)
     func testPostRawSession() {
         let jsonBook: String = "{\"name\": \"bookName\",\"author\": \"bookAuthor\",\"rating\": 4}"
         let objectBook = Book(name: "bookName", author: "bookAuthor", rating: 4)
@@ -114,4 +115,5 @@ class TestSessionsRoutes: KituraTest {
             })
         })
     }
+    #endif
 }


### PR DESCRIPTION
Codable sessions was introduce in Kitura-Session. However this is only available from Swift 4.1 and above. This PR removes the codable sessions for Swift 4.0 so that it still compiles.